### PR TITLE
CI: raise ROCm ccache to 2G, drop 1d eviction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -451,6 +451,9 @@ jobs:
     env:
       ROCM_VERSION: "7.14.0"
       GPU_TARGETS: "gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
+      # rocm-sdk re-expands clang from the wheel every run, so its mtime always
+      # differs and the default compiler_check=mtime misses every object.
+      CCACHE_COMPILERCHECK: content
 
     steps:
       - uses: actions/checkout@v3
@@ -478,9 +481,7 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.16
         with:
           key: windows-rocm-${{ env.ROCM_VERSION }}-x64
-          # 500M (the action default) truncates this build's cache at save, and
-          # a truncated cache still restores then misses: 4.13% hits measured.
-          max-size: 2G
+          evict-old-files: 1d
 
       - name: Install ROCm with Wheels
         if: steps.cache-rocm.outputs.cache-hit != 'true'
@@ -597,6 +598,8 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.16
         with:
           key: ubuntu-rocm-cmake-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}
+          evict-old-files: 1d
+          # Plateaus at the 500M default (88.19% full, 142 misses/run).
           max-size: 2G
 
       - name: Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,7 +478,9 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.16
         with:
           key: windows-rocm-${{ env.ROCM_VERSION }}-x64
-          evict-old-files: 1d
+          # 500M (the action default) truncates this build's cache at save, and
+          # a truncated cache still restores then misses: 4.13% hits measured.
+          max-size: 2G
 
       - name: Install ROCm with Wheels
         if: steps.cache-rocm.outputs.cache-hit != 'true'
@@ -595,7 +597,7 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.16
         with:
           key: ubuntu-rocm-cmake-${{ matrix.ROCM_VERSION }}-${{ matrix.build }}
-          evict-old-files: 1d
+          max-size: 2G
 
       - name: Dependencies
         id: depends

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,6 +482,8 @@ jobs:
         with:
           key: windows-rocm-${{ env.ROCM_VERSION }}-x64
           evict-old-files: 1d
+          # Upper bound, not a reservation: ccache stores only what it compiles.
+          max-size: 2G
 
       - name: Install ROCm with Wheels
         if: steps.cache-rocm.outputs.cache-hit != 'true'


### PR DESCRIPTION
The Windows ROCm leg has a 4.13% ccache hit rate and the Ubuntu one is pressed against its cache cap. This fixes both, at their actual causes.

**An earlier revision of this PR treated the two as the same problem and got Windows wrong. See the review comments below for the correction; this description reflects the current diff.**

### Windows: the compiler hash never recurs

Four consecutive Windows ROCm runs:

| job | cache size vs cap | hits |
| --- | --- | --- |
| 92812296767 | `0.2 / 0.5 (42.26%)` | `13 / 385 (3.38%)` |
| 93021695452 | `0.2 / 0.5 (42.54%)` | `17 / 387 (4.39%)` |
| 93045420552 | `0.3 / 0.5 (64.40%)` | `16 / 387 (4.13%)` |
| 93056114309 | `0.3 / 0.5 (65.52%)` | `16 / 387 (4.13%)` |

The cache never reaches the 500M cap, and the hit rate is flat regardless of how full it is. Two runs restoring different caches produced identical hit counts, which is what a restored cache contributing nothing looks like.

Every Windows run logs `Cache not found for input keys: rocm-wheels-7.14.0-Windows` and then re-expands the devel tree, so `clang.exe` gets a fresh mtime each run. ccache runs with `compiler_check = mtime` (the default), which hashes the compiler mtime and size, so every object is keyed to a hash that never comes back. Ubuntu never expands a devel tree and sits at 73.65%.

Fix: `CCACHE_COMPILERCHECK: content` on the Windows job. The ccache manual recommends `content` for exactly this case, noting it "makes ccache very slightly slower compared to mtime, but makes it cope better with compiler upgrades during a build bootstrapping process".

### Ubuntu: genuinely cap-bound

Job 93056114302 reports `Cache size (GB): 0.4 / 0.5 (88.19%)` with 142 misses per run, and the Ubuntu entries plateau at the cap (0.236, 0.239, 0.433, 0.437 GB). That is the LRU-cleanup regime, so `max-size: 2G`.

Windows gets the same 2G. It is not cap-bound today, but `max-size` is an upper bound rather than a reservation: ccache stores only what it compiles and GitHub bills actual bytes, so a cap a build never approaches costs nothing. For scale, llama.cpp's 38 build legs all run at 2G and total 10.69 GB, mean 0.28 GB, with no single leg above 0.9 GB. Uniform settings also mean one less thing to re-tune when a build grows.

### `evict-old-files: 1d` stays on both

An earlier revision removed it on the theory that it discards objects still in use. That is wrong: the ccache manual defines `--evict-older-than AGE` as removing files "used less recently than AGE", and ccache refreshes mtime on every cache hit. It only reaps objects untouched for 24 hours, and on Windows it is the only thing reaping objects that can never be hit again.

### Scope

Six lines: one job-level env var, `max-size` on the Ubuntu ccache step, and `evict-old-files` left as upstream has it. Parsing the workflow before and after and comparing with the ccache `with:` blocks masked confirms nothing else moved. The Windows ccache block now matches upstream leejet byte for byte again, so only the Ubuntu `max-size` line is a divergence to carry through the next sync.

### Measuring it

The first Windows run after merge is not a clean signal: `rocm-wheels-7.14.0-Windows` was only created at `2026-08-08T04:34:22`, after all four runs above, so a jump could partly be that cache landing. Watch the second run.

### Not in this PR

Cache usage here is 10.39 GB (`active_caches_size_in_bytes: 10390575412`), so there is no janitor in this change. Two things for later: the timestamped ccache keys accumulate generations where only the newest is prefix-reachable, and `rocm-wheels-7.14.0-Windows` exists four times at 1.31 GB under one key, which is ref-scoped copies from PR branches rather than generations.
