### PR TITLE
CI: ccache the SD CUDA leg

### DIFF
--- a/.github/workflows/unsloth-sd-prebuilt.yml
+++ b/.github/workflows/unsloth-sd-prebuilt.yml
@@ -349,6 +349,11 @@ jobs:
     continue-on-error: true
     if: ${{ needs.resolve.outputs.exists != 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
+    # One source of truth for both: the ccache key has to track whatever changes
+    # the objects, and these two do.
+    env:
+      CUDA_VERSION: "12.8.1"
+      CUDA_ARCHS: "75;80;86;89;90;100;120"
     steps:
       - name: Checkout mirror (tooling)
         uses: actions/checkout@v4
@@ -379,7 +384,7 @@ jobs:
         id: cuda-toolkit
         uses: Jimver/cuda-toolkit@v0.2.22
         with:
-          cuda: "12.8.1"
+          cuda: ${{ env.CUDA_VERSION }}
           method: "network"
           # sub-packages are installed as cuda-<name>-12-8. cuBLAS is not under that
           # prefix (it ships as libcublas / libcublas-dev), so it has to go in the
@@ -388,6 +393,34 @@ jobs:
           sub-packages: '["nvcc", "cudart", "cudart-dev", "thrust"]'
           non-cuda-sub-packages: '["libcublas", "libcublas-dev"]'
 
+      # This leg rebuilt every object on every run: 3903 s of the 4121 s job on
+      # 2026-08-09, and 4942 s on the run before it, with no speedup between the
+      # two. The repo held no cache entry for it at all, only build.yml's ROCm
+      # ones.
+      #
+      # The key carries the CUDA version and the architecture list because both
+      # decide the objects. ccache hashes compiler identity into every entry, so
+      # a cache written by another toolkit can never hit -- a version-less key
+      # is what held the llama.cpp ROCm legs at a 0% hit rate and made them that
+      # pipeline's critical path (llama.cpp#88). restore-keys lets a new tag
+      # start from the previous generation instead of from nothing.
+      - name: ccache key
+        id: cckey
+        run: echo "archs=$(echo "$CUDA_ARCHS" | tr ';' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
+        with:
+          key: sd-cuda-${{ env.CUDA_VERSION }}-${{ steps.cckey.outputs.archs }}-${{ needs.resolve.outputs.tag }}
+          restore-keys: |
+            sd-cuda-${{ env.CUDA_VERSION }}-${{ steps.cckey.outputs.archs }}
+          append-timestamp: false
+          variant: ccache
+          max-size: 2G
+          # Saved by the explicit step below instead, so a failed build still
+          # keeps what it compiled.
+          save: false
+
       - name: Build sd-cli + sd-server (CUDA)
         working-directory: src
         run: |
@@ -395,6 +428,10 @@ jobs:
           # Turing through Blackwell. 12.8 is the first toolkit that can emit sm_100 (B200) and
           # sm_120 (RTX 50), and anything older than Turing is not a realistic host for a 20 GB
           # video denoiser. build.yml's Windows leg uses the same list plus 61 and 70.
+          #
+          # The CUDA launcher matters more than the other two here: Jimver installs nvcc outside
+          # the default search, and nvcc is nearly the whole build, so caching only C/CXX would
+          # leave the expensive half uncached.
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DSD_BUILD_EXAMPLES=ON \
@@ -402,8 +439,12 @@ jobs:
             -DSD_WEBP=OFF -DSD_WEBM=OFF \
             -DGGML_NATIVE=OFF \
             -DSD_CUDA=ON \
-            -DCMAKE_CUDA_ARCHITECTURES='75;80;86;89;90;100;120'
+            -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCHS" \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
           cmake --build build --config Release -j "$(nproc)" --target sd-cli sd-server
+          ccache --show-stats
 
       - name: Bundle the CUDA runtime beside the binaries
         run: |
@@ -443,6 +484,28 @@ jobs:
           name: sd-${{ needs.resolve.outputs.tag }}-bin-Linux-Ubuntu-22.04-x86_64-cuda12
           path: dist/sd-${{ needs.resolve.outputs.tag }}-bin-Linux-Ubuntu-22.04-x86_64-cuda12.zip
           if-no-files-found: error
+
+      - name: Evict stale ccache files
+        # !cancelled(), unlike the save below: a cancelled job gets one short
+        # teardown window that is not replenished, and the save is what needs
+        # it.
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: ccache --evict-older-than 14d
+
+      - name: Save ccache
+        # Save even when the build failed. The objects compiled before the
+        # failure still count, and this leg is continue-on-error, so a failure
+        # here is routine. always(), not !cancelled(): a job killed by the cap
+        # takes the cancellation path, and that is the most expensive case to
+        # lose (llama.cpp#81).
+        if: ${{ always() }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.ccache
+          # Trailing dash keeps this distinct from the key the ccache action
+          # restored from, so the save is never a no-op against itself.
+          key: ccache-sd-cuda-${{ env.CUDA_VERSION }}-${{ steps.cckey.outputs.archs }}-${{ needs.resolve.outputs.tag }}-
 
   build-windows:
     name: win-cpu-x64

--- a/.github/workflows/unsloth-sd-prebuilt.yml
+++ b/.github/workflows/unsloth-sd-prebuilt.yml
@@ -444,7 +444,8 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
           cmake --build build --config Release -j "$(nproc)" --target sd-cli sd-server
-          ccache --show-stats
+          # Diagnostic only, under set -e: never fail a good build over stats.
+          ccache --show-stats || true
 
       - name: Bundle the CUDA runtime beside the binaries
         run: |


### PR DESCRIPTION
## Problem

[Run 31289281107](https://github.com/unslothai/stable-diffusion.cpp/actions/runs/31289281107) took 72m43s. One job is the whole run:

| job | duration |
| --- | --- |
| **Linux-Ubuntu-22.04-x86_64-cuda12** | **4121s (68.7 min)** |
| Darwin-macOS-x86_64 | 424s |
| win-cpu-x64 | 219s |
| Darwin-macOS-arm64 | 199s |
| Linux-Ubuntu-24.04-aarch64 | 189s |
| Linux-Ubuntu-22.04-x86_64 | 175s |
| Assemble + publish | 116s |
| Resolve tag + stamp source | 36s |

Inside that job, one step: `Build sd-cli + sd-server (CUDA)` at 3903s. Toolkit install was 82s, packaging 57s, upload 31s.

The cause is that this pipeline has no ccache anywhere. `unsloth-sd-prebuilt.yml` has zero mentions of `ccache`, `COMPILER_LAUNCHER` or `actions/cache`, so the CUDA leg recompiles all seven architectures from scratch every time. The only ccache in the repo is in `build.yml`, keyed `windows-rocm-*` and `ubuntu-rocm-cmake-*`.

Three things confirm it rather than one:

- the repo's Actions cache list has 20 entries totalling 9.68 GiB, and every one is a ROCm key from `build.yml`. Nothing was ever written for this job.
- consecutive runs show no warm-cache effect: 31271264076 took 4942s, then 31289281107 took 4121s.
- at 9.68 GiB the repo is far from the 50 GB cache limit, so this is not eviction. It simply never caches.

## Change

Ports the pattern already used by the llama.cpp CUDA legs, which run 407-665s each with 90-94% hit rates on a larger codebase.

- ccache action pinned to the same SHA the llama.cpp workflows use, `max-size: 2G`.
- The key carries the CUDA version and the architecture list, because both decide the objects. ccache hashes compiler identity into every entry, so a cache written by another toolkit can never hit. A version-less key is exactly what held the llama.cpp ROCm legs at a 0% hit rate and made them that pipeline's critical path (unslothai/llama.cpp#88).
- `restore-keys` drops the tag so a new tag starts from the previous generation instead of from nothing.
- Both the key and the cmake invocation read one pair of job-level env vars, so the key cannot silently drift from what it is keying on.
- All three compiler launchers, including `CMAKE_CUDA_COMPILER_LAUNCHER`. That one carries this build: nvcc is nearly all of the 65 minutes, and Jimver installs it outside the default search, so caching only C and CXX would leave the expensive half uncached.
- Save in an explicit step on `always()`, so a failed or capped job keeps what it compiled (unslothai/llama.cpp#81). This leg is `continue-on-error`, so a failure here is routine rather than exceptional.
- `ccache --evict-older-than 14d` on `!cancelled()`, so the short teardown window goes to the save rather than to housekeeping.
- `ccache --show-stats` after the build, so the hit rate is visible in the log instead of having to be inferred.

Behaviour is otherwise unchanged: same toolkit, same architecture list, same targets, same bundle.

## Expected effect

Cold cache is unchanged at around 65 minutes. Warm runs should drop that leg well under 10 minutes and take the pipeline off a 70 minute critical path.

## Not in this PR

The leg still builds all seven architectures (`75;80;86;89;90;100;120`) serially in one job, where llama.cpp spreads the same span across parallel matrix profiles. That is the other half of the 65 minutes and a larger change, worth deciding separately.

`-j "$(nproc)"` is also left alone. llama.cpp pins its multi-arch nvcc builds to `-j 3` because they peak at about 3 GB host RSS, and 4 parallel nvcc processes on a 16 GB runner is close to the edge, but this job has not been failing on memory so I have not touched it.

## Testing

The workflow parses, and I checked every step's resolved inputs rather than just the step list, which caught the new steps having been spliced between `path:` and `if-no-files-found:` on the upload step. Confirmed against GitHub's context availability table that the `env` context is valid in `steps.*.with`, since `cuda:` now reads from it.

The real check is the next run's `ccache --show-stats` and the second run after that, which is the first one able to hit.
