### PR TITLE
Gate the full-set artifact on failure and add the keep_artifacts hatch

### DIFF
--- a/.github/workflows/unsloth-sd-prebuilt.yml
+++ b/.github/workflows/unsloth-sd-prebuilt.yml
@@ -60,6 +60,11 @@ on:
         default: false
         required: false
         type: boolean
+      keep_artifacts:
+        description: 'Keep this run''s artifacts even if it publishes nothing (artifact-only test runs)'
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -647,12 +652,26 @@ jobs:
           done
           [ "$fail" = 0 ] || { echo "ERROR: refusing to publish a partial release" >&2; exit 1; }
 
+      # Only on a run that did NOT succeed, matching llama.cpp. Uploading this
+      # unconditionally duplicated every bundle in the run -- measured at 1.34 GiB
+      # per run, byte-for-byte the same content as the six -bin- artifacts beside
+      # it. On a green publish those bytes are already release assets, and
+      # reclaim below cannot delete this copy because an aggregate matches no
+      # single asset name, so it was the largest survivor of every cleanup.
+      #
+      # !success() rather than failure(): a cancelled run is exactly when a
+      # human wants the rescue bundle.
       - name: Upload full set (artifact fallback)
+        if: ${{ always() && !success() }}
         uses: actions/upload-artifact@v4
         with:
           name: unsloth-sd-prebuilt-${{ needs.resolve.outputs.tag }}
           path: dist/*
-          if-no-files-found: error
+          # warn, not error: an early failure can leave dist/ absent, and a
+          # missing debug bundle must not turn a diagnosable failure into a
+          # confusing second one.
+          if-no-files-found: warn
+          overwrite: true
           retention-days: 7
 
       - name: Publish GitHub release
@@ -782,7 +801,7 @@ jobs:
         # run's release. So the rule is simply that nothing will ever consume
         # these -- a publish:false dispatch is a test, and a cancelled or failed
         # run is not resumable past the missing legs -- and they are deleted.
-        if: ${{ needs.assemble.outputs.published != 'true' }}
+        if: ${{ needs.assemble.outputs.published != 'true' && inputs.keep_artifacts != true }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Follow-up to #10. A review of that PR found that the reclaim job cannot delete the largest artifact of every run, and that the port dropped an escape hatch it depends on.

## 1. reclaim could not delete the largest artifact of every run

`assemble` uploads `unsloth-sd-prebuilt-<tag>` (`path: dist/*`) unconditionally. That aggregate matches no single release asset name, so reclaim always classifies it `KEEP`. On a green publish its bytes are already release assets, so it is a pure duplicate that survives every cleanup.

Measured on run `31289281107`: the aggregate is 1,442,716,005 B against the six `-bin-` artifacts totalling 1,442,714,834 B, identical to within a manifest, plus a 126 MiB source artifact. reclaim was deleting 1.34 GiB of 2.81 GiB, about 48%, and the single biggest item was always the one left behind.

llama.cpp gates its equivalent upload `if: ${{ always() && !success() }}`, with the reasoning recorded there: uploading it ahead of the publish gate cost storage per run for a bundle nothing reads, and published unverified builds, since any signed-in user can download an artifact from a public repo, for runs that deliberately never released. That gating was missed when this pipeline was ported.

This PR applies it, plus `if-no-files-found: warn` (an early failure can leave `dist/` absent, and a missing debug bundle must not turn a diagnosable failure into a confusing second one) and `overwrite: true`.

`!success()` rather than `failure()` is deliberate: a cancelled run is exactly when a human wants the rescue bundle. The comment in #10 that presented keeping this artifact as a feature is replaced.

## 2. No way to keep artifacts from a run that publishes nothing

llama.cpp guards its unpublished-deletion step with `&& inputs.keep_artifacts != true`; the port dropped it, and this repo has no such input. This repo has no retry workflow either, so `assemble` being skipped after a failed leg meant `published` was empty and every successfully built bundle was discarded, with no way to opt out. A `publish:false` dispatch, the documented default for testing, also deleted its own output.

This PR adds the `keep_artifacts` boolean input and the `&& inputs.keep_artifacts != true` guard.

## Verification

- YAML parses; the `assemble` upload step now carries `if: ${{ always() && !success() }}`.
- reclaim published-path condition unchanged; unpublished-path is now `needs.assemble.outputs.published != 'true' && inputs.keep_artifacts != true`.
- `workflow_dispatch` inputs are now `ref, min_age_hours, publish, keep_artifacts`.

## Note on scope

`build.yml` in this repo still has 7 upload steps at the 90-day default retention, including a 563 MiB CUDA runtime zip, and it is where this repo's live artifact storage actually accumulates today. Deliberately out of scope here; worth a separate pass.